### PR TITLE
Use DOCKER_BUILDKIT=0 flag for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ The only external finance system currently supported is E5.
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-pay-api:latest` command or run the following steps to build image locally:
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-pay-api:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-pay-api:latest .`

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,6 +1,6 @@
 custom_build(
   ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-pay-api',
-  command = 'docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [
     sync(
       local_path = './assets',


### PR DESCRIPTION
Docker releases >=2.4.0.0 have BuildKit enabled by default - this breaks image builds due to a known issue (https://github.com/moby/buildkit/issues/816) with BuildKit and ONBUILD COPY --from directives which we use in our runtime image.

Prefixing `docker build` commands with `DOCKER_BUILDKIT=0` fixes the issue